### PR TITLE
Feature/cli fixes

### DIFF
--- a/src/fr/kazanmw/maestro/Ordonnanceur.java
+++ b/src/fr/kazanmw/maestro/Ordonnanceur.java
@@ -26,6 +26,7 @@ import fr.kazanmw.services.MessagesService;
 public class Ordonnanceur {
 
 	private static final SearchModule spider = new SearchModule();
+	private static final Object RESULT_FILE_EXTENSION = ".txt";
 	private static String resultMatches = StringUtils.EMPTY;
 	private static String resultsDirectoryForOutputFile = StringUtils.EMPTY;
 	private static DateTimeFormatter filenameFormatter = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
@@ -134,6 +135,7 @@ public class Ordonnanceur {
 		filePathBuildr.append(StringUtils.isNotEmpty(directoryParam) ? directoryParam : FileUtils.getUserDirectory());
 		filePathBuildr.append(File.separator);
 		filePathBuildr.append(LocalDateTime.now().format(filenameFormatter));
+		filePathBuildr.append(RESULT_FILE_EXTENSION);
 		try {
 			FileService.writeFile(filePathBuildr.toString(), fileContentParam);
 			result = filePathBuildr.toString();

--- a/src/fr/kazanmw/maestro/Ordonnanceur.java
+++ b/src/fr/kazanmw/maestro/Ordonnanceur.java
@@ -133,7 +133,9 @@ public class Ordonnanceur {
 		String result;
 		final StringBuilder filePathBuildr = new StringBuilder();
 		filePathBuildr.append(StringUtils.isNotEmpty(directoryParam) ? directoryParam : FileUtils.getUserDirectory());
-		filePathBuildr.append(File.separator);
+		if(!StringUtils.endsWith(directoryParam, File.separator)) {
+			filePathBuildr.append(File.separator);
+		}
 		filePathBuildr.append(LocalDateTime.now().format(filenameFormatter));
 		filePathBuildr.append(RESULT_FILE_EXTENSION);
 		try {

--- a/src/fr/kazanmw/modules/SearchModule.java
+++ b/src/fr/kazanmw/modules/SearchModule.java
@@ -59,7 +59,7 @@ public class SearchModule {
 		final StringBuilder result = new StringBuilder();
 		if (!paramMap.isEmpty()) {
 			paramMap.entrySet().stream()
-					.forEach(entry -> result.append(entry.getKey()).append(System.lineSeparator())
+					.forEach(entry -> result.append(System.lineSeparator()).append(entry.getKey()).append(System.lineSeparator())
 							.append(fr.kazanmw.maestro.utils.StringUtils.concatenateStringListToSingleMultilinedString(entry.getValue(),
 									PunctuationStringConstants.FIVE_WHITESPACES)));
 		}


### PR DESCRIPTION
Correction de quelques comportements : 

- Ajout de l'extension de fichier '.txt' au fichier de résultats
- Ajout d'un saut de ligne dans le fichier de résultats entre chaque groupe de clones trouvés
- Ajout d'une condition pour éviter affichage de double séparateur système ('\') dans le chemin absolu affiché pour le fichier de résultat